### PR TITLE
Update snap_from_yaml.gml

### DIFF
--- a/scripts/snap_from_yaml/snap_from_yaml.gml
+++ b/scripts/snap_from_yaml/snap_from_yaml.gml
@@ -7,6 +7,7 @@
 /// 
 /// @param string              The YAML string to be decoded
 /// @param [replaceKeywords]   Whether to replace keywords (true, false, null) with boolean/undefined equivalents. Default to <true>
+/// @param [trackFieldOrder]   Whether to track the order of struct fields as they appear in the YAML string (stored in __snap_field_order field on each GML struct). Default to <false>
 /// 
 /// @jujuadams 2020-11-01
 
@@ -30,6 +31,7 @@ function snap_from_yaml()
 {
     var _string = argument[0];
     var _replace_keywords = ((argument_count > 1) && (argument[1] != undefined))? argument[1] : true;
+    var _track_field_order = ((argument_count > 2) && (argument[2] != undefined))? argument[2] : false;
     
     var _buffer = buffer_create(string_byte_length(_string)+1, buffer_fixed, 1);
     buffer_write(_buffer, buffer_text, _string);
@@ -39,7 +41,7 @@ function snap_from_yaml()
     
     buffer_delete(_buffer);
     
-    return (new __snap_from_yaml_builder(_tokens_array, _replace_keywords)).result;
+    return (new __snap_from_yaml_builder(_tokens_array, _replace_keywords, _track_field_order)).result;
 }
 
 function __snap_from_yaml_tokenizer(_buffer) constructor
@@ -273,10 +275,11 @@ function __snap_from_yaml_tokenizer(_buffer) constructor
     }
 }
 
-function __snap_from_yaml_builder(_tokens_array, _replace_keywords) constructor
+function __snap_from_yaml_builder(_tokens_array, _replace_keywords, _track_field_order) constructor
 {
     tokens_array = _tokens_array;
     replace_keywords = _replace_keywords;
+	track_field_order = _track_field_order;
     
     token_count  = array_length(tokens_array);
     token_index  = 0;
@@ -320,11 +323,21 @@ function __snap_from_yaml_builder(_tokens_array, _replace_keywords) constructor
             {
                 var _indent_limit = indent;
                 var _struct = {};
+				if (track_field_order) {
+					var field_index = 0;
+					_struct.__snap_field_order = [];
+				}
                 
                 --token_index;
                 while(token_index < token_count)
                 {
                     var _key = tokens_array[token_index][1];
+										
+					if (track_field_order) {
+						// add the key to the __snap_field_order array
+						_struct.__snap_field_order[field_index++] = _key;
+					}
+					
                     token_index += 2; //Skip over the struct symbol
                     
                     var _last_line = line;
@@ -435,11 +448,20 @@ function __snap_from_yaml_builder(_tokens_array, _replace_keywords) constructor
         else if (_type == __SNAP_YAML.JSON_STRUCT_START)
         {
             var _struct = {};
+			if (track_field_order) {
+				var field_index = 0;
+				_struct.__snap_field_order = [];
+			}
             
             read_to_next();
             while((token_index < token_count) && (tokens_array[token_index][0] != __SNAP_YAML.JSON_STRUCT_END))
             {
                 var _key = read();
+				
+				if (track_field_order) {
+					// add the key to the __snap_field_order array
+					_struct.__snap_field_order[field_index++] = _key;
+				}
                 
                 read_to_next();
                 if (tokens_array[token_index][0] == __SNAP_YAML.JSON_COLON)


### PR DESCRIPTION
Add 'track_field_order' option to snap_from_yaml
* tracks the order the fields of a struct are declared in in the source yaml string
* stores the field names in order as an array under '__snap_field_order' on the resulting struct

Basically the issue this addresses is that if I have some YAML like:

```
ingredients:
  apples: 1
  bananas: 7
  oranges: 3
```

GML struct implementation means that `variable_struct_get_names` is not guaranteed (or likely) to return those field names in order. For my UI system, I often want to be able to know what the order was in the original data file, and so my solution is this change which tracks the field order on the resulting SNAP struct, when the optional parameter is supplied.

(I understand this might be a little... questionable, so feel free to let me know if you have alternative ideas :D)