### PR TITLE
reduntant 4th argument in foreach function

### DIFF
--- a/scripts/foreach/foreach.gml
+++ b/scripts/foreach/foreach.gml
@@ -65,7 +65,7 @@ function foreach()
             var _key = ds_map_find_first(_ds);
             repeat(ds_map_size(_ds))
             {
-                _function(_ds[? _key], _i, _key, undefined);
+                _function(_ds[? _key], _i, _key);
                 _key = ds_map_find_next(_ds, _key);
                 ++_i;
             }


### PR DESCRIPTION
Method passed as 2nd argument to `foreach()` can use up to 3 arguments, but on ds_map case, this function call got fourth argument (and it's value is always `undefined`).
I think it's a copy-paste typo.

Nothing big, as it's not causing any errors.