### PR TITLE
Added BOM header check for snap_from_csv

### DIFF
--- a/scripts/snap_from_csv/snap_from_csv.gml
+++ b/scripts/snap_from_csv/snap_from_csv.gml
@@ -31,6 +31,15 @@ function snap_from_csv()
     var _word_start  = 0;
     var _in_string   = false;
     var _string_cell = false;
+	
+	var _bom_a = buffer_peek( _buffer, 0, buffer_u8);
+	var _bom_b = buffer_peek( _buffer, 1, buffer_u8);
+	var _bom_c = buffer_peek( _buffer, 2, buffer_u8);
+	if (( _bom_a == 0xEF) && ( _bom_b == 0xBB) && ( _bom_c == 0xBF) ) {
+		buffer_seek(_buffer, buffer_seek_start, 3);	
+		_size -= 3;
+		_word_start += 3;
+	}
     
     repeat(_size)
     {

--- a/scripts/snap_from_csv/snap_from_csv.gml
+++ b/scripts/snap_from_csv/snap_from_csv.gml
@@ -32,10 +32,7 @@ function snap_from_csv()
     var _in_string   = false;
     var _string_cell = false;
 	
-	var _bom_a = buffer_peek( _buffer, 0, buffer_u8);
-	var _bom_b = buffer_peek( _buffer, 1, buffer_u8);
-	var _bom_c = buffer_peek( _buffer, 2, buffer_u8);
-	if (( _bom_a == 0xEF) && ( _bom_b == 0xBB) && ( _bom_c == 0xBF) ) {
+	if ((buffer_get_size(_buffer) >= 4) && (buffer_peek(_buffer, 0, buffer_u32) & 0xFFFFFF == 0xBFBBEF)) {
 		buffer_seek(_buffer, buffer_seek_start, 3);	
 		_size -= 3;
 		_word_start += 3;


### PR DESCRIPTION
Without the BOM header check, this causes issues with CSV files that were made in a spreadsheet software and have BOM at the start. Causing the parser to read the first cell wrong. While it seems like nothing out of the ordinary, as it renders just fine. It adds an invisible character. Breaking any comparison checks. (such as `if ("Language" == _csvArray[0][0])`)

This fix implements a BOM header check. And if BOM is present, advances the buffer position head by 3 and modifies the size/word_start variables to compensate.