### PR TITLE
Typo

### DIFF
--- a/scripts/snap_from_ini_string/snap_from_ini_string.gml
+++ b/scripts/snap_from_ini_string/snap_from_ini_string.gml
@@ -73,7 +73,7 @@ function snap_from_ini_string()
                     ||  (_value == 10) //Newline
                     ||  (_value == 13) //Newline
                     ||  (_value == ord(";")) //Comment semicolon
-                    ||  (_in_string && (_value == ord("\"")) && (buffer_peek(_buffer, buffer_tell(_buffer)-2, buffer_u8) != ord("\\")))) //Unescaped double quote
+                    ||  (_in_string && (_value == ord("\")) && (buffer_peek(_buffer, buffer_tell(_buffer)-2, buffer_u8) != ord("\\")))) //Unescaped double quote
                     {
                         if (_value == ord(";")) _in_comment = true;
                         


### PR DESCRIPTION
There is a double quotation mark, rendering half the code as string. Not sure why it says I removed the newline from the bottom of the file. I have tried to resubmit without it but it has the same error.