### PR TITLE
Fixed an issue with names in functions

### DIFF
--- a/scripts/SnapBufferWriteBinary/SnapBufferWriteBinary.gml
+++ b/scripts/SnapBufferWriteBinary/SnapBufferWriteBinary.gml
@@ -43,7 +43,7 @@ function SnapBufferWriteBinary(_buffer, _value)
             if (!is_string(_name)) show_error("Keys must be strings\n ", true);
             
             buffer_write(_buffer, buffer_string, string(_name));
-            SnapToBinary(_buffer, _struct[$ _name]);
+            SnapBufferWriteBinary(_buffer, _struct[$ _name]);
             
             ++_i;
         }
@@ -59,7 +59,7 @@ function SnapBufferWriteBinary(_buffer, _value)
         var _i = 0;
         repeat(_count)
         {
-            SnapToBinary(_buffer, _array[_i]);
+            SnapBufferWriteBinary(_buffer, _array[_i]);
             ++_i;
         }
     }

--- a/scripts/SnapBufferWriteBinary/SnapBufferWriteBinary.gml
+++ b/scripts/SnapBufferWriteBinary/SnapBufferWriteBinary.gml
@@ -20,7 +20,7 @@
     0x0B  -  instance ID reference
 */
 
-function SnapToBinary(_buffer, _value)
+function SnapBufferWriteBinary(_buffer, _value)
 {
     if (is_method(_value)) //Implicitly also a struct so we have to check this first
     {

--- a/scripts/SnapBufferWriteJSON/SnapBufferWriteJSON.gml
+++ b/scripts/SnapBufferWriteJSON/SnapBufferWriteJSON.gml
@@ -8,7 +8,7 @@
 /// 
 /// @jujuadams 2022-10-30
 
-function SnapToJSONBuffer(_buffer, _value, _pretty = false, _alphabetise = false, _accurateFloats = false)
+function SnapBufferWriteJSON(_buffer, _value, _pretty = false, _alphabetise = false, _accurateFloats = false)
 {
     return __SnapToJSONBufferValue(_buffer, _value, _pretty, _alphabetise, _accurateFloats, "");
 }

--- a/snap.yyp
+++ b/snap.yyp
@@ -91,8 +91,8 @@
   ],
   "Folders": [
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"SNAP","folderPath":"folders/SNAP.yy","order":0,},
-    {"resourceType":"GMFolder","resourceVersion":"1.0","name":"Custom Binary","folderPath":"folders/SNAP/Custom Binary.yy","order":8,},
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"CSV","folderPath":"folders/SNAP/CSV.yy","order":6,},
+    {"resourceType":"GMFolder","resourceVersion":"1.0","name":"Custom Binary","folderPath":"folders/SNAP/Custom Binary.yy","order":8,},
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"GML","folderPath":"folders/SNAP/GML.yy","order":12,},
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"Grids & 2D Arrays","folderPath":"folders/SNAP/Grids & 2D Arrays.yy","order":13,},
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"INI","folderPath":"folders/SNAP/INI.yy","order":11,},
@@ -107,10 +107,10 @@
     {"resourceType":"GMAudioGroup","resourceVersion":"1.3","name":"audiogroup_default","targets":-1,},
   ],
   "TextureGroups": [
-    {"resourceType":"GMTextureGroup","resourceVersion":"1.3","name":"Default","isScaled":true,"compressFormat":"bz2","autocrop":true,"border":2,"mipsToGenerate":0,"groupParent":null,"targets":-1,},
+    {"resourceType":"GMTextureGroup","resourceVersion":"1.3","name":"Default","isScaled":true,"compressFormat":"bz2","loadType":"default","directory":"","autocrop":true,"border":2,"mipsToGenerate":0,"groupParent":null,"targets":-1,},
   ],
   "IncludedFiles": [],
   "MetaData": {
-    "IDEVersion": "2022.900.0.209",
+    "IDEVersion": "2022.9.1.51",
   },
 }


### PR DESCRIPTION
Two functions within SNAP has a different name, causing SNAP to not to compile properly on YYC.
Mainly `SnapBufferWriteBinary` and `SnapBufferWriteJSON`.