### PR TITLE
Fix SnapDeepCopy and Legacy method binding

### DIFF
--- a/scripts/SnapDeepCopy/SnapDeepCopy.gml
+++ b/scripts/SnapDeepCopy/SnapDeepCopy.gml
@@ -35,7 +35,7 @@ function __SnapDeepCopyInner(_value, _oldStruct, _newStruct)
         if (_self == _oldStruct)
         {
             //If this method is bound to the source struct, create a new method bound to the new struct
-            _value = method(_newStruct, method_get_index(_value));
+            _copy = method(_newStruct, method_get_index(_value));
         }
         else if (_self != undefined)
         {

--- a/scripts/SnapDeepCopyLegacy/SnapDeepCopyLegacy.gml
+++ b/scripts/SnapDeepCopyLegacy/SnapDeepCopyLegacy.gml
@@ -27,7 +27,7 @@ function __SnapDeepCopyLegacyInner(_value, _oldStruct, _newStruct)
         if (_self == _oldStruct)
         {
             //If this method is bound to the source struct, create a new method bound to the new struct
-            _value = method(_newStruct, method_get_index(_value));
+            _copy = method(_newStruct, method_get_index(_value));
         }
         else if (_self != undefined)
         {


### PR DESCRIPTION
Since method() isn't changing the method struct found in _value, but assigning a new struct to _value, the reference to _value stored in _copy isnt reflecting the change to the newly bound method.

Storing newly bound method directly to _copy fixes issue.